### PR TITLE
Make dired-launch.el work on BSD-systems

### DIFF
--- a/dired-launch.el
+++ b/dired-launch.el
@@ -27,7 +27,7 @@
   (setf dired-launch-default-launcher
 	(cond ((eq system-type 'darwin)
 	       '("open"))
-	      ((eq system-type 'gnu/linux)
+	      ((or (eq system-type 'gnu/linux) (eq system-type 'berkeley-unix))
 	       (if (executable-find "mimeopen")
 		   '("mimeopen" "-n")
 		 '("xdg-open")))
@@ -144,7 +144,7 @@
   (cond ((eq system-type 'darwin)
 	 (dired-launch-homebrew
 	  (dired-get-marked-files t current-prefix-arg)))
-	((eq system-type 'gnu/linux)
+	((or (eq system-type 'gnu/linux) (eq system-type 'berkeley-unix))
 	 (dired-launch-homebrew
 	  (dired-get-marked-files t current-prefix-arg)))
         ((eq system-type 'cygwin)


### PR DESCRIPTION
The programs that are used to launch programs on Linux are also
available on BSD-systems. So, don't exclude them.

Ideally, one could make a Unix-like variable that includes all the
different Unix variants, but that should be for another day.